### PR TITLE
Change main team access from fiwg stemcells team to vm deployment team

### DIFF
--- a/bosh-deploy-concourse/vars.yml
+++ b/bosh-deploy-concourse/vars.yml
@@ -10,13 +10,13 @@ main_team.auth_config: |
   roles:
   - name: owner
     github:
-      orgs: ["cloudfoundry:wg-foundational-infrastructure-stemcell-release-engineering-bosh-approvers"]
+      orgs: ["cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers"]
     local:
       users: ["ci-user"]
   - name: viewer
     github:
       orgs:
-      - "cloudfoundry:wg-foundational-infrastructure-stemcell-release-engineering-bosh-reviewers"
+      - "cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-reviewers"
       - "cloudfoundry:wg-foundational-infrastructure-integrated-databases-mysql-postgres-reviewers"
       - "cloudfoundry:wg-foundational-infrastructure-integrated-databases-mysql-postgres-approvers"
 max_containers: 1000


### PR DESCRIPTION
[From](https://github.com/orgs/cloudfoundry/teams/wg-foundational-infrastructure-stemcell-release-engineering-bosh-approvers) [to](https://github.com/orgs/cloudfoundry/teams/wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers)

Seems like we did this wrong originally and is preventing some people from having access.