### PR TITLE
Reduce Concourse workers root disk size in cloud-config.yml

### DIFF
--- a/ci/tasks/deploy-bosh-director/cloud-config.yml
+++ b/ci/tasks/deploy-bosh-director/cloud-config.yml
@@ -17,17 +17,17 @@ vm_types:
   - name: concourse_worker_4_16
     cloud_properties:
       machine_type: e2-standard-4 # 4 CPU, 16 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 500
       root_disk_type: pd-ssd
   - name: concourse_worker_8_32
     cloud_properties:
       machine_type: e2-standard-8 # 8 CPU, 32 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 500
       root_disk_type: pd-ssd
   - name: concourse_worker_16_64
     cloud_properties:
       machine_type: e2-standard-16 # 16 CPU, 64 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 500
       root_disk_type: pd-ssd
   - name: compilation
     cloud_properties:


### PR DESCRIPTION
Google’s SSD Persistent Disks (pd-ssd) scale performance by size formula is:

- Operations:
  - Baseline IOPS = 30 IOPS × disk size (GB), up to 120 000 IOPS per volume
- Throughput
  - Baseline throughput = 0.48 MiB/s × disk size (GB), up to 2400 MiB/s per volume

In our case we are reducing:
- Operations:
  - From `1000 GB pd-ssd → 1000×30 = 30 000 IOPS` to `500 GB pd-ssd → 500×30 = 15 000 IOPS 
- Throughput:
  - From `1000×0.48 ≈ 480 MiB/s` to  `500×0.48 ≈ 240 MiB/s`

<img width="1512" alt="Screenshot 2025-07-08 at 15 12 38" src="https://github.com/user-attachments/assets/d34ba2e7-5810-43b8-aba2-a7e9bc4c0bc4" />

Based on the monitoring data from the last month above this should be enough. I didn't check the disk usage because there are no metrics for this and SSH is disabled for our workers but I expect 500GB to be enough. This will save us ~300$ per month on "SSD backed PD Capacity".


