### PR TITLE
Create new storage-cli team

### DIFF
--- a/ci/teams/storage-cli.yml
+++ b/ci/teams/storage-cli.yml
@@ -1,0 +1,15 @@
+roles:
+  - name: owner
+    github:
+      teams:
+      - cloudfoundry:wg-foundational-infrastructure-storage-cli-approvers
+    local:
+      users: ["ci-user"]
+  - name: viewer
+    github:
+      teams:
+      - cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers
+      - cloudfoundry:wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-reviewers
+      - cloudfoundry:wg-foundational-infrastructure-storage-cli-reviewers
+    local:
+      users: []


### PR DESCRIPTION
This is the result of:
rfc: https://github.com/cloudfoundry/community/pull/1253 and: https://github.com/cloudfoundry/community/pull/1275

There is a new storage-cli area which will own all the storage cli repos