### PR TITLE
Increase Concourse workers disk back to 1TB

### DIFF
--- a/ci/tasks/deploy-bosh-director/cloud-config.yml
+++ b/ci/tasks/deploy-bosh-director/cloud-config.yml
@@ -17,17 +17,17 @@ vm_types:
   - name: concourse_worker_4_16
     cloud_properties:
       machine_type: e2-standard-4 # 4 CPU, 16 GB RAM
-      root_disk_size_gb: 500
+      root_disk_size_gb: 1000
       root_disk_type: pd-ssd
   - name: concourse_worker_8_32
     cloud_properties:
       machine_type: e2-standard-8 # 8 CPU, 32 GB RAM
-      root_disk_size_gb: 500
+      root_disk_size_gb: 1000
       root_disk_type: pd-ssd
   - name: concourse_worker_16_64
     cloud_properties:
       machine_type: e2-standard-16 # 16 CPU, 64 GB RAM
-      root_disk_size_gb: 500
+      root_disk_size_gb: 1000
       root_disk_type: pd-ssd
   - name: compilation
     cloud_properties:

--- a/ci/tasks/deploy-bosh-director/cloud-config.yml
+++ b/ci/tasks/deploy-bosh-director/cloud-config.yml
@@ -17,17 +17,17 @@ vm_types:
   - name: concourse_worker_4_16
     cloud_properties:
       machine_type: e2-standard-4 # 4 CPU, 16 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 750
       root_disk_type: pd-ssd
   - name: concourse_worker_8_32
     cloud_properties:
       machine_type: e2-standard-8 # 8 CPU, 32 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 750
       root_disk_type: pd-ssd
   - name: concourse_worker_16_64
     cloud_properties:
       machine_type: e2-standard-16 # 16 CPU, 64 GB RAM
-      root_disk_size_gb: 1000
+      root_disk_size_gb: 750
       root_disk_type: pd-ssd
   - name: compilation
     cloud_properties:


### PR DESCRIPTION
This reverts commit 26eb5292bd6d01384def7ac2e145e79512c07926 because concourse has disk issue. See https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/bump-deps/builds/161#L6877d244:4